### PR TITLE
Correctly update membership after redirect flow

### DIFF
--- a/CRM/Core/Payment/GoCardless.php
+++ b/CRM/Core/Payment/GoCardless.php
@@ -124,7 +124,7 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
         'payment_processor_id' => $this->_paymentProcessor['id'],
         "description"          => $params['description'],
       ];
-      foreach (['contributionID', 'contributionRecurID', 'contactID'] as $_) {
+      foreach (['contributionID', 'contributionRecurID', 'contactID', 'membershipID'] as $_) {
         if (!empty($params[$_])) {
           $sesh_store[$redirect_flow->id][$_] = $params[$_];
         }

--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -187,7 +187,7 @@ class CRM_GoCardlessUtils
       // If we don't have the amount yet, load it from the Contribution record.
       if (!isset($amount)) {
         $result = civicrm_api3('Contribution', 'getsingle', ['id' => $deets['contributionID']]);
-        $amount = $result['amount'];
+        $amount = $result['total_amount'];
       }
 
       if (!in_array($interval_unit, ['year', 'month', 'week'])) {

--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -260,9 +260,8 @@ class CRM_GoCardlessUtils
         // Calculate the end date for the membership, although hopefully this will be renewed automatically.
         // People expect their membership to start immediately, although the payment might not come through for a couple of days.
         // Use today's date as the start date, and contribution date + N * interval for end date.
-        $membershipEndDateString = date("Y-m-d",strtotime(date("Y-m-d", strtotime($start_date)) . " +$interval_duration $interval_unit_civi_format"));
         // Update membership dates.
-        civicrm_api("Membership" ,"create" , [
+        civicrm_api3("Membership" ,"create" , [
           'id'         => $deets['membershipID'],
           'end_date'   => date('Y-m-d', strtotime($subscription->start_date . " + $interval_interval $interval_unit")),
           'start_date' => date('Y-m-d'),

--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -164,20 +164,20 @@ class CRM_GoCardlessUtils
 
       // We need to know the interval.
       // This comes from the membership record or the recurring contribution record.
-      if (!empty($deets['membershipID'])) {
+      if (!empty($deets['contributionRecurID'])) {
+        // Load interval details from the recurring contribution record.
+        $result = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $deets['contributionRecurID']]);
+        $interval_unit = $result['frequency_unit'];
+        $interval_interval = $result['frequency_interval'];
+        $amount = $result['amount'];
+      }
+      else if (!empty($deets['membershipID'])) {
         // This is a membership. Load the interval from the type.
         $result = civicrm_api3('Membership', 'getsingle',
           ['id' => $deets['membershipID'], 'api.MembershipType.getsingle' => []]
         );
         $interval_unit = $result['api.MembershipType.getsingle']['duration_unit'];
         $interval_interval = $result['api.MembershipType.getsingle']['duration_interval'];
-      }
-      elseif (!empty($deets['contributionRecurID'])) {
-        // Load interval details from the recurring contribution record.
-        $result = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $deets['contributionRecurID']]);
-        $interval_unit = $result['frequency_unit'];
-        $interval_interval = $result['frequency_interval'];
-        $amount = $result['amount'];
       }
       else {
         // Something is wrong.


### PR DESCRIPTION
Hi, thanks for sharing this plugin, its exactly what I needed!

I found an issue when using it for recurring memberships where the membership would never get updated. I'm new to CiviCRM so what I've changed might not make sense but it seems to work!

I switched the test for `membershipID` vs `contributionRecurID` around because it seems that in the case of recurring memberships both exist, and the `ContributionRecur` record holds all the information needed (including the `amount`) so there's no need to query the `Contribution` record.

I also noticed that the field `amount` doesn't exist for a `Contribution`, so I switched that to `total_amount`. 