### PR TITLE
doPaymentsFailed() refers to wrong variable

### DIFF
--- a/CRM/GoCardless/Page/Webhook.php
+++ b/CRM/GoCardless/Page/Webhook.php
@@ -236,7 +236,7 @@ class CRM_GoCardless_Page_Webhook extends CRM_Core_Page {
     }
 
     // Make the changes.
-    civicrm_api3('Contribution', 'create', $update);
+    civicrm_api3('Contribution', 'create', $contribution);
   }
   /**
    * Process webhook for 'mandate' resource type, action 'finished'.


### PR DESCRIPTION
This looks like a typo to me. The function doPaymentsFailed() refers to a variable $update but this isn't defined.  I think it should refer to $contribution.

I haven't tested this myself, but spotted it while reading through the code.