### PR TITLE
Limiting the number of payments/installments as per issue 34.

### DIFF
--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -156,7 +156,7 @@ class CRM_GoCardlessUtils
 
     // Check installments is positive
     if (array_key_exists('installments', $deets)) {
-      if ($deets['installments'] < 0) {
+      if ($deets['installments'] <= 0) {
         throw new Exception("Number of payments must be positive, not " . $deets['installments']);
       }
       $installments = $deets['installments'];

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Other things to note
 
 - Although "Beta", this has been in production use since November 2016. The usual disclaimers apply :-)
 
-- **This takes ongoing regular payments with no end date.** If you need to specify an end date, wait until <https://github.com/artfulrobot/uk.artfulrobot.civicrm.gocardless/issues/34> is implemented/fixed, or help resource it by a PR or contacting me with a budget.
-
 - Daily recurring is not supported by GoCardless so you should not enable this option when configuring your forms. If you do users will get an error message: "Error Sorry, we are unable to set up your Direct Debit. Please call us."
 
 - Taking one offs is [not supported/implemented yet](https://github.com/artfulrobot/uk.artfulrobot.civicrm.gocardless/issues/12).


### PR DESCRIPTION
Introduces a basic validation negative number of installments not allowed.

Create variable to hold parameters for api call to GoCardless instead of doing inline to allow passing of optional paramenters.

If number of payments is present add "installments" to params to Go Cardless call.

Update Readme.