### PR TITLE
Fix for issue 45

### DIFF
--- a/CRM/Core/Payment/GoCardless.php
+++ b/CRM/Core/Payment/GoCardless.php
@@ -180,10 +180,10 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
     $emails = [];
     $addresses = [];
     foreach ($params as $civi_prop => $value) {
-      if ($civi_prop == 'first_name') {
+      if ($civi_prop === 'first_name') {
         $customer['given_name'] = $value;
       }
-      elseif ($civi_prop == 'last_name') {
+      elseif ($civi_prop === 'last_name') {
         $customer['family_name'] = $value;
       }
       elseif (preg_match('/^email-(\d)+$/', $civi_prop, $matches)) {


### PR DESCRIPTION
Assumed input params to be strings and comparing with `==` but the membership forms include nested arrays with numeric keys. Since 'some string' evaluates to 0, `0 == 'some string'` and the first string tested was first name, so that got clobbered. Using `===` instead has solved this.