### PR TITLE
Users are unable to install if they previously used vedaconsulting gocardless

### DIFF
--- a/gocardless.php
+++ b/gocardless.php
@@ -69,6 +69,7 @@ function gocardless_civicrm_install() {
       'is_active' => 1,
       'is_default' => 0,
       'user_name_label' => 'API Access Token',
+      'options' => ['match' => "name"],
       'signature_label' => 'Webhook Secret',
       'url_api_default' => 'https://api.gocardless.com/',
       'url_api_test_default' => 'https://api-sandbox.gocardless.com/',


### PR DESCRIPTION
When installing this version of gocardless I was unable to do so due to the table already existing, I disabled the extension for uk.co.vedaconsulting.payment.gocardlessdd as advised. 

This change allows the user to install without having to uninstall the previous extension which causes data loss. 