### PR TITLE
Correct payment_processor_id in import script

### DIFF
--- a/cli/import-from-gc.php
+++ b/cli/import-from-gc.php
@@ -172,7 +172,7 @@ foreach ($subscriptions->records as $subscription) {
       "contribution_status_id" => STATUS_IN_PROGRESS, // 1:Completed, 2: pending, 3: cancelled, 4: failed, 5: in progress ...)
       "is_test"                => 0,
       "cycle_day"              => 1,
-      "payment_processor_id"   => $processor->id,
+      "payment_processor_id"   => $processor->getID(),
       "financial_type_id"      => GC_IMPORT_FINANCIAL_TYPE_ID,
       "payment_instrument_id"  => GC_IMPORT_PAYMENT_INSTRUMENT_ID,
     ];


### PR DESCRIPTION
This previously created civicrm_contribution_recur entries with
payment_processor_id NULL.