### PR TITLE
catch exception to allow check to complete

### DIFF
--- a/gocardless.php
+++ b/gocardless.php
@@ -242,13 +242,12 @@ function gocardless_civicrm_validateForm($formName, &$fields, &$files, &$form, &
  * See https://github.com/artfulrobot/uk.artfulrobot.civicrm.gocardless/issues/51
  */
 function gocardless_civicrm_check(&$messages) {
-  $result = civicrm_api3('OptionValue', 'getsingle', [
+  try {
+    civicrm_api3('OptionValue', 'getsingle', [
       'option_group_id' => "payment_instrument",
       'name' => "direct_debit_gc",
-  ]);
-  $financial_account_id = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($result['id'], NULL, 'civicrm_option_value');
-
-  if (empty($financial_account_id)) {
+    ]);
+  } catch (\Exception $e) {
     $messages[] = new CRM_Utils_Check_Message(
       'gocardless_missing_financial_account',
       E::ts('Please visit Administer » CiviContribute » Payment Methods and edit '


### PR DESCRIPTION
Running `cv api system.check` on a site that was newly upgraded to gocardless 1.9 I got the following output:

```
Array
(
    [is_error] => 1
    [error_message] => Expected one OptionValue but found 0
)
```

Catching the exception fixes the issue for me and I now see "Missing Financial Account for GoCardless" on my status screen.

My might try an be more specific and replace `Exception` with `CiviCRM_API3_Exception`. What do you think? Happy to be guided by you on that.