### PR TITLE
Implement new doCancelRecurring and support payment propertyBag

### DIFF
--- a/CRM/Core/Payment/GoCardless.php
+++ b/CRM/Core/Payment/GoCardless.php
@@ -573,7 +573,14 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
 
     switch ($context) {
       case 'cancelRecurDetailText':
-        $text .= ' <br/><strong>' . E::ts('GoCardless will be automatically notified and the subscription will be cancelled.') . '</strong>';
+        // $params['selfService'] added via https://github.com/civicrm/civicrm-core/pull/17687
+        $params['selfService'] = $params['selfService'] ?? TRUE;
+        if ($params['selfService']) {
+          $text .= ' <br/><strong>' . E::ts('GoCardless will be automatically notified and the subscription will be cancelled.') . '</strong>';
+        }
+        else {
+          $text .= ' <br/><strong>' . E::ts("If you select 'Send cancellation request..' then GoCardless will be automatically notified and the subscription will be cancelled.") . '</strong>';
+        }
     }
     return $text;
   }

--- a/CRM/Core/Payment/GoCardless.php
+++ b/CRM/Core/Payment/GoCardless.php
@@ -98,29 +98,38 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
   /**
    * Attempt to cancel the subscription at GoCardless.
    *
-   * @see supportsCancelRecurring()
+   * @param \Civi\Payment\PropertyBag $propertyBag
    *
-   * @param string $message
-   * @param array $params
-   * which refers to 'subscriptionId'
-   *
-   * @return bool
+   * @return array|null[]
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function cancelSubscription(&$message = '', $params = []) {
-    if (empty($params['subscriptionId'])) {
-      throw new PaymentProcessorException("cancelSubscription requires a subscriptionId");
+  public function doCancelRecurring(\Civi\Payment\PropertyBag $propertyBag) {
+    // By default we always notify the processor and we don't give the user the option
+    // because supportsCancelRecurringNotifyOptional() = FALSE
+    // @fixme setIsNotifyProcessorOnCancelRecur was added in 5.27 - remove method_exists once minVer is 5.27
+    if (method_exists($propertyBag, 'setIsNotifyProcessorOnCancelRecur')) {
+      if (!$propertyBag->has('isNotifyProcessorOnCancelRecur')) {
+        // If isNotifyProcessorOnCancelRecur is NOT set then we set our default
+        $propertyBag->setIsNotifyProcessorOnCancelRecur(TRUE);
+      }
+      $notifyProcessor = $propertyBag->getIsNotifyProcessorOnCancelRecur();
     }
-    // Get the GoCardless subscription ID, stored in processor_id
-    $contrib_recur = civicrm_api3('ContributionRecur', 'getsingle', ['processor_id' => $params['subscriptionId']]);
-    $subscription_id = $contrib_recur['processor_id'];
+    else {
+      // CiviCRM < 5.27
+      $notifyProcessor = (boolean) CRM_Utils_Request::retrieveValue('send_cancel_request', 'Boolean', TRUE, FALSE, 'POST');
+    }
+
+    if (!$notifyProcessor) {
+      return ['message' => ts('Successfully cancelled the subscription in CiviCRM ONLY.')];
+    }
 
     $log_message = __FUNCTION__ . ": "
-    . json_encode(['subscription_id' => $subscription_id, 'contribution_recur_id' => $params['id']])
-    . ' ';
+      . json_encode(['subscription_id' => $propertyBag->getRecurProcessorID(), 'contribution_recur_id' => $propertyBag->getContributionRecurID()])
+      . ' ';
     try {
       $gc_api = $this->getGoCardlessApi();
-      $gc_api->subscriptions()->cancel($subscription_id);
+      // The GoCardless subscription ID is stored in processor_id
+      $gc_api->subscriptions()->cancel($propertyBag->getRecurProcessorID());
       CRM_Core_Error::debug_log_message("$log_message SUCCESS", FALSE, 'GoCardless', PEAR_LOG_INFO);
     }
     catch (\GoCardlessPro\Core\Exception\ApiException $e) {
@@ -128,13 +137,11 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
       $this->logGoCardlessException("$log_message FAILED", $e);
       // repackage as PaymentProcessorException
       throw new PaymentProcessorException($e->getMessage());
-
     }
     catch (\GoCardlessPro\Core\Exception\MalformedResponseException $e) {
       // Unexpected non-JSON response
       $this->logGoCardlessException("$log_message FAILED", $e);
       throw new PaymentProcessorException('Unexpected response type from GoCardless');
-
     }
     catch (\GoCardlessPro\Core\Exception\ApiConnectionException $e) {
       // Network error
@@ -142,7 +149,35 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
       throw new PaymentProcessorException('Network error, please try later.');
     }
 
-    $message = "Successfully cancelled the subscription at GoCardless.";
+    return ['message' => ts('Successfully cancelled the subscription at GoCardless.')];
+  }
+
+  /**
+   * Attempt to cancel the subscription at GoCardless.
+   * @deprecated Remove when min CiviCRM version is 5.25
+   *
+   * @see supportsCancelRecurring()
+   *
+   * @param string $message
+   * @param array|\Civi\Payment\PropertyBag $params
+   *
+   * @return bool
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function cancelSubscription(&$message = '', $params = []) {
+    $propertyBag = \Civi\Payment\PropertyBag::cast($params);
+    if (!$propertyBag->has('recurProcessorID')) {
+      throw new PaymentProcessorException("cancelSubscription requires the recurProcessorID");
+    }
+
+    // contributionRecurID is set when doCancelRecurring is called directly (from 5.25)
+    if (!$propertyBag->has('contributionRecurID')) {
+      $contrib_recur = civicrm_api3('ContributionRecur', 'getsingle', ['processor_id' => $propertyBag->getRecurProcessorID()]);
+      $propertyBag->setContributionRecurID($contrib_recur['id']);
+    }
+
+    $message = $this->doCancelRecurring($propertyBag)['message'];
     return TRUE;
   }
 
@@ -515,11 +550,32 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
   }
 
   /**
+   * Does the processor support the user having a choice as to whether to cancel the recurring with the processor?
+   *
+   * If this returns TRUE then there will be an option to send a cancellation request in the cancellation form.
+   *
+   * @return bool
+   */
+  protected function supportsCancelRecurringNotifyOptional() {
+    return TRUE;
+  }
+
+  /**
    * Shorthand method to determine if this processor is a test one.
    */
   public function isTestMode() {
     $pp = $this->getPaymentProcessor();
     return $pp['is_test'];
+  }
+
+  public function getText($context, $params) {
+    $text = parent::getText($context, $params);
+
+    switch ($context) {
+      case 'cancelRecurDetailText':
+        $text .= ' <br/><strong>' . E::ts('GoCardless will be automatically notified and the subscription will be cancelled.') . '</strong>';
+    }
+    return $text;
   }
 
 }

--- a/CRM/Core/Payment/GoCardless.php
+++ b/CRM/Core/Payment/GoCardless.php
@@ -168,7 +168,7 @@ class CRM_Core_Payment_GoCardless extends CRM_Core_Payment {
   public function cancelSubscription(&$message = '', $params = []) {
     $propertyBag = \Civi\Payment\PropertyBag::cast($params);
     if (!$propertyBag->has('recurProcessorID')) {
-      throw new PaymentProcessorException("cancelSubscription requires the recurProcessorID");
+      throw new \Civi\Payment\Exception\PaymentProcessorException("cancelSubscription requires the recurProcessorID");
     }
 
     // contributionRecurID is set when doCancelRecurring is called directly (from 5.25)

--- a/info.xml
+++ b/info.xml
@@ -16,20 +16,12 @@
     <url desc="Support">https://github.com/artfulrobot/uk.artfulrobot.civicrm.gocardless</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-03-24</releaseDate>
-  <version>1.9.3</version>
-  <develStage>stable</develStage>
+  <releaseDate>2020-06-10</releaseDate>
+  <version>1.9.4-dev</version>
+  <develStage>beta</develStage>
   <compatibility>
-    <ver>4.7</ver>
-    <ver>5.0</ver>
-    <ver>5.3</ver>
-    <ver>5.8</ver>
-    <ver>5.13</ver>
-    <ver>5.19</ver>
-    <ver>5.21</ver>
     <ver>5.24</ver>
   </compatibility>
-  <comments></comments>
   <civix>
     <namespace>CRM/GoCardless</namespace>
   </civix>


### PR DESCRIPTION
This implements support for payment propertyBag and `doCancelRecurring()`/`cancelSubscription()` for subscription cancellations.

Some notes:
1. I've implemented `supportsCancelRecurringNotifyOptional()` and set it to TRUE. This means that the user will see an option to notify gocardless (defaults to Yes) on versions of CiviCRM that support this (5.27).
In the backend they will see:
![image](https://user-images.githubusercontent.com/2052161/85879897-09e1d900-b7d3-11ea-9ebb-2a942fdd02d4.png)
And the frontend (with https://github.com/civicrm/civicrm-core/pull/17687):
![image](https://user-images.githubusercontent.com/2052161/85880123-65ac6200-b7d3-11ea-9695-1d0da1c226b6.png)

1. This drops support for CiviCRM < 5.24 - I think you'll have trouble getting everything working on versions much older anyway..