### PR TITLE
hook to amend params or override completeRedirectFlowWithGoCardless()

### DIFF
--- a/CRM/GoCardless/Hook.php
+++ b/CRM/GoCardless/Hook.php
@@ -1,0 +1,46 @@
+<?php
+
+class CRM_GoCardless_Hook {
+
+  /**
+   * This hook allows to override gocardless subscription process or
+   * parameters.
+   *
+   * @param array $deets with the following keys
+   *
+   * - test_mode bool.
+   * - session_token string used in creating the flow with getRedirectFlow().
+   * - redirect_flow_id
+   * - description
+   * - payment_processor_id
+   * - interval_unit yearly/monthly/weekly
+   * - amount (in GBP, e.g. 10.50)
+   * - installments (optional positive integer number of payments to take)
+   * - and additional recurring details like interval, unit, amount,
+   *   installments
+   *
+   * @param array $result variable to put results in when overriding
+   *   completeRedirectFlowWithGoCardless()
+   * @param bool $callMain set this to false if
+   *   completeRedirectFlowWithGoCardless() should be skipped.
+   *
+   * @return mixed
+   *   Ignored value.
+   */
+  public static function handleRedirectFlowWithGoCardless($deets, &$result, &$callMain) {
+    $null = NULL;
+    return CRM_Utils_Hook::singleton()->invoke([
+      'deets',
+      'result',
+      'callMain',
+    ],
+      $deets,
+      $result,
+      $callMain,
+      $null,
+      $null,
+      $null,
+      'civicrm_handleRedirectFlowWithGoCardless');
+  }
+
+}

--- a/CRM/GoCardless/Hook.php
+++ b/CRM/GoCardless/Hook.php
@@ -6,7 +6,7 @@ class CRM_GoCardless_Hook {
    * This hook allows to override gocardless subscription process or
    * parameters.
    *
-   * @param array $deets with the following keys
+   * @param array $details with the following keys
    *
    * - test_mode bool.
    * - session_token string used in creating the flow with getRedirectFlow().
@@ -21,22 +21,19 @@ class CRM_GoCardless_Hook {
    *
    * @param array $result variable to put results in when overriding
    *   completeRedirectFlowWithGoCardless()
-   * @param bool $callMain set this to false if
-   *   completeRedirectFlowWithGoCardless() should be skipped.
    *
    * @return mixed
    *   Ignored value.
    */
-  public static function handleRedirectFlowWithGoCardless($deets, &$result, &$callMain) {
+  public static function handleRedirectFlowWithGoCardless($details, &$result) {
     $null = NULL;
     return CRM_Utils_Hook::singleton()->invoke([
-      'deets',
-      'result',
-      'callMain',
+      'details',
+      'result'
     ],
-      $deets,
+      $details,
       $result,
-      $callMain,
+      $null,
       $null,
       $null,
       $null,

--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -313,7 +313,13 @@ class CRM_GoCardlessUtils {
         $params['installments'] = $installments;
       }
 
-      $result = static::completeRedirectFlowWithGoCardless($deets + $params);
+      $result = [];
+      $callMain = TRUE;
+      // allow hook to amend params or override completeRedirectFlowWithGoCardless()
+      CRM_GoCardless_Hook::handleRedirectFlowWithGoCardless($deets + $params, $result, $callMain);
+      if ($callMain) {
+        $result = static::completeRedirectFlowWithGoCardless($deets + $params);
+      }
       // It's the subscription we're interested in.
       $subscription = $result['subscription'];
     }

--- a/CRM/GoCardlessUtils.php
+++ b/CRM/GoCardlessUtils.php
@@ -314,10 +314,9 @@ class CRM_GoCardlessUtils {
       }
 
       $result = [];
-      $callMain = TRUE;
       // allow hook to amend params or override completeRedirectFlowWithGoCardless()
-      CRM_GoCardless_Hook::handleRedirectFlowWithGoCardless($deets + $params, $result, $callMain);
-      if ($callMain) {
+      CRM_GoCardless_Hook::handleRedirectFlowWithGoCardless($deets + $params, $result);
+      if (empty($result)) {
         $result = static::completeRedirectFlowWithGoCardless($deets + $params);
       }
       // It's the subscription we're interested in.


### PR DESCRIPTION
We working on a requirement to modify subscriptions in a way that for yearly memberships create direct debit with payment taken now and then next member payment taken Jan following year.

The solution we implementing is not very generic at this point, that we can submit to this extension, and providing a hook helps to keep the work clean and separate in another extension. 

The pull request adds a hook around completeRedirectFlowWithGoCardless() which helps modify params or override the method, allowing further to modify the subscription schedule for specific cases.