### PR TITLE
Implement doPayment instead of doTransferCheckout #114

### DIFF
--- a/tests/phpunit/GoCardlessTest.php
+++ b/tests/phpunit/GoCardlessTest.php
@@ -197,7 +197,7 @@ class GoCardlessTest extends PHPUnit\Framework\TestCase implements HeadlessInter
       'entryURL' => 'http://example.com/somwhere',
     ];
     $obj->setGoCardlessApi($api_prophecy->reveal());
-    $url = $obj->doTransferCheckoutWorker($params, 'contribute');
+    $url = $obj->createRedirectFlow($params, 'contribute');
     $this->assertInternalType('string', $url);
     $this->assertNotEmpty('string', $url);
     $this->assertEquals("https://gocardless.com/somewhere", $url);


### PR DESCRIPTION
I believe this fixes #114 
Tests don't cover this, but they do still pass :-)

- Implement doPayment and remove doTransferCheckout (and doDirectPayment)
- change name of an internal method to something more obvious (doTransferCheckoutWorker → createRedirectFlowURL)

Does it look ok to you, @mattwire ?
